### PR TITLE
fixed linking to achievements pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
                             </div>
                             <h3>No. 1 CTF team in India</h3><br>
                             <p>No. 1 CTF team in the country, for 4 years running! Currently #21, we are also among the top 30 teams worldwide as per <a href="https://ctftime.org/team/662">CTFtime</a>.<br/></p>
-			    <br><a href="achievements.html#Team" class="genric-btn success circle">Tools, Talks and Workshops</a>
+			    <br><a href="achievements.html#Team" class="genric-btn success circle">Team Achievements</a>
 
                             </div>
                     </a>
@@ -154,7 +154,7 @@
                             </div>
                             <h3>Talks and Workshops</h3>
                             <p>Our members have been invited and have been a part of various security conferences such as DEFCON, BSides and much more. <br/><br/></p>
-			    <br><a href="achievements.html#Talks" class="genric-btn success circle">Tools, Talks and Workshops</a>
+			    <br><a href="tools_talks_wks.html" class="genric-btn success circle">Tools, Talks and Workshops</a>
                         </div>
                     </a>
                 </div>


### PR DESCRIPTION
Initially there was two "_Tools, Talks and Workshops_" in **index.html** .where one was changed to "_team Achievements_" and fixed linking of "_Tools, Talks and Workshops_"